### PR TITLE
Updated pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
       <version>3.12.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Updated the dependency to fix CVE-2021-44228 / Log4Shell.

The groupID changed because it was moved to another repo: 
(read note on previous repo page https://mvnrepository.com/artifact/org.apache.commons/commons-io )

org.apache.commons/commons-io >> commons-io/commons-io




